### PR TITLE
Make Studio artifact debug helper update the client correctly

### DIFF
--- a/raceforthegalaxy.game.php
+++ b/raceforthegalaxy.game.php
@@ -13605,12 +13605,6 @@ ADD `card_played_subphase` smallint(2) NOT NULL DEFAULT '-1';";
         $this->drawCardForPlayer(self::getCurrentPlayerId(), $n);
     }
 
-    function drawArtefact($type)
-    {
-        $player_id = self::getCurrentPlayerId();
-        $artefact = $this->artefacts->pickCard($type, $player_id);
-    }
-
     function debug_money() {
         $this->money();
     }
@@ -13637,11 +13631,18 @@ ADD `card_played_subphase` smallint(2) NOT NULL DEFAULT '-1';";
             ));
     }
 
-    // Add this artefact to current player
-    function debug_aa(int $player_id, int $artefact_id)
+    // Add this artefact to a player's hand
+    function debug_aa(int $player_id, int $artefact_type_id)
     {
-        $sql = "INSERT INTO `artefact` (`card_type`, `card_type_arg`, `card_location`, `card_location_arg`) VALUES ('$artefact_id', 0, 'hand', $player_id) ";
+        $sql = "INSERT INTO `artefact` (`card_type`, `card_type_arg`, `card_location`, `card_location_arg`) VALUES ('$artefact_type_id', 0, 'hand', $player_id) ";
         self::DbQuery($sql);
+        $card_id = self::DbGetLastId();
+        $artefact = $this->artefacts->getCard($card_id);
+        // Studio debug helpers bypass the normal orb pickup flow, so we need
+        // to send the hand-update notification explicitly.
+        self::notifyPlayer($player_id, 'pickArtefact', '', array(
+            'card' => $artefact,
+        ));
     }
 
     function debug_endGame()

--- a/raceforthegalaxy.js
+++ b/raceforthegalaxy.js
@@ -5776,9 +5776,16 @@ define([
                 }
             },
             notif_pickArtefact: function(notif) {
-                this.playerHandArt.addToStockWithId(notif.args.card.type, notif.args.card.id, 'artefact_' + notif.args.card.id);
-                dojo.destroy('artefact_' + notif.args.card.id);
-                dojo.removeClass($(`orb_${notif.args.x}_${notif.args.y}`), 'breeding_tube');
+                var artefact_id = 'artefact_' + notif.args.card.id;
+                // Studio debug helpers create artefacts directly in hand, so they do not
+                // include orb coordinates or a board artefact node to animate from.
+                if (typeof notif.args.x != 'undefined' && typeof notif.args.y != 'undefined') {
+                    this.playerHandArt.addToStockWithId(notif.args.card.type, notif.args.card.id, artefact_id);
+                    dojo.destroy(artefact_id);
+                    dojo.removeClass($(`orb_${notif.args.x}_${notif.args.y}`), 'breeding_tube');
+                } else {
+                    this.playerHandArt.addToStockWithId(notif.args.card.type, notif.args.card.id);
+                }
             },
             notif_drawOrb: function(notif) {
                 var field = $('orb_card_' + notif.args.orbcard_type + '_count_' + notif.args.player_id);


### PR DESCRIPTION
<git-pr-chain>


Fix AA debug function.

There was existing debug code to force-add an alien artifact to a
player's hand.  But using it caused a JS crash; we'd try to play an
animation but there was no corresponding orb card, and boom.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #6 👈 **YOU ARE HERE**
1. #3
1. #5


</git-pr-chain>




