### PR TITLE
Rename "six-cost dev" to "variable-point card"

### DIFF
--- a/gamepreferences.json
+++ b/gamepreferences.json
@@ -112,20 +112,20 @@
         }
     },
     "6": {
-        "name": "6 cost development scoring display",
+        "name": "Variable-point card scoring display",
         "needReload": true,
         "values": {
             "1": {
                 "name": "Never",
-                "cssPref": "sixdev_scoring_no"
+                "cssPref": "variable_vp_scoring_no"
             },
             "2": {
                 "name": "Hover \/ Tap",
-                "cssPref": "sixdev_scoring_hover_tap"
+                "cssPref": "variable_vp_scoring_hover_tap"
             },
             "3": {
                 "name": "Always",
-                "cssPref": "sixdev_scoring_yes"
+                "cssPref": "variable_vp_scoring_yes"
             }
         },
         "default": 2

--- a/raceforthegalaxy.css
+++ b/raceforthegalaxy.css
@@ -213,8 +213,8 @@ html.new_design {
 }
 
 .card_name_black .keyword,
-.six_dev .keyword,
-.six_dev_scoring_text .keyword {
+.variable_vp .keyword,
+.variable_vp_scoring_text .keyword {
     text-shadow: -1px -1px 0 black, 1px -1px 0 black, -1px 1px 0 black, 1px 1px 0 black;
 }
 
@@ -297,7 +297,7 @@ html.new_design {
     background-size: 110px;
 }
 
-.card_size_tiny .six_dev {
+.card_size_tiny .variable_vp {
     right: 8px;
     top: 34px;
     font-size: 7px;
@@ -373,7 +373,7 @@ html.new_design {
     background-size: 132px;
 }
 
-.card_size_small .six_dev {
+.card_size_small .variable_vp {
     right: 10px;
     top: 40px;
     font-size: 9px;
@@ -448,7 +448,7 @@ html.new_design {
     background-size: 153px;
 }
 
-.card_size_medium .six_dev {
+.card_size_medium .variable_vp {
     right: 12px;
     top: 47px;
     font-size: 9px;
@@ -522,7 +522,7 @@ html.new_design {
     background-size: 195px;
 }
 
-.card_size_large .six_dev {
+.card_size_large .variable_vp {
     right: 15px;
     top: 60px;
     font-size: 10px;
@@ -587,7 +587,7 @@ html.new_design {
     top: 50px;
 }
 
-.card_size_huge .six_dev {
+.card_size_huge .variable_vp {
     right: 18px;
     top: 71px;
     font-size: 10px;
@@ -945,28 +945,28 @@ html.new_design {
 #gambling_world_stats th {
     font-weight: bold;
 }
-/*** Six dev scoring tooltip table ***/
-.six_dev_scoring td {
+/*** Variable-point card scoring tooltip table ***/
+.variable_vp_scoring td {
     padding: 1px;
     text-align: center;
 }
-td.six_dev_scoring_text,
-td.six_dev_scoring_name {
+td.variable_vp_scoring_text,
+td.variable_vp_scoring_name {
     padding-left: 5px;
     text-align: left;
 }
-td.six_dev_scoring_name {
+td.variable_vp_scoring_name {
     font-weight: bold;
     text-transform: uppercase;
 }
 
-.cardtooltip td.six_dev_scoring_card_only,
-.cardtooltip tr.six_dev_scoring_card_only {
+.cardtooltip td.variable_vp_scoring_card_only,
+.cardtooltip tr.variable_vp_scoring_card_only {
     display: none;
 }
 
-/*** Six dev scoring card table ***/
-.six_dev {
+/*** Variable-point card scoring table ***/
+.variable_vp {
     position: absolute;
     background-color: rgba(255,255,255,0.4);
     border-style:ridge;
@@ -974,15 +974,15 @@ td.six_dev_scoring_name {
     display: none;
     text-align: center;
 }
-.six_dev td.six_dev_scoring_text,
-.six_dev td.six_dev_scoring_name,
-.six_dev tr.six_dev_scoring_tooltip_only {
+.variable_vp td.variable_vp_scoring_text,
+.variable_vp td.variable_vp_scoring_name,
+.variable_vp tr.variable_vp_scoring_tooltip_only {
     display: none;
 }
 
-.sixdev_scoring_hover_tap .stockitem:hover .six_dev,
-.sixdev_scoring_hover_tap .card:hover .six_dev,
-.sixdev_scoring_yes .six_dev {
+.variable_vp_scoring_hover_tap .stockitem:hover .variable_vp,
+.variable_vp_scoring_hover_tap .card:hover .variable_vp,
+.variable_vp_scoring_yes .variable_vp {
     display: block;
 }
 /*** icons ***/

--- a/raceforthegalaxy.game.php
+++ b/raceforthegalaxy.game.php
@@ -824,7 +824,7 @@ class RaceForTheGalaxy extends Bga\GameFramework\Table
             // 6 cost devs and worlds with similar scoring
             if ($card['type'] == 'development' && $card['cost'] == 6 && $card_type_id != 151
                 || in_array($card_type_id, [247, 267, 283, 294])) {
-                $result['card_types'][$card_type_id]['sixdev_scoring'] = $this->sixcostdev_html($card_type_id);
+                $result['card_types'][$card_type_id]['variable_vp_scoring'] = $this->variableVpScoringHtml($card_type_id);
             }
         }
 
@@ -1246,7 +1246,7 @@ class RaceForTheGalaxy extends Bga\GameFramework\Table
                 if (isset($power['arg']['pr'])) {
                     if (isset($power['rebel'])) {
                         $html .= sprintf(self::_("Gain %s PRG if you place a Rebel development"), $power['arg']['pr']) ;
-                    } elseif (isset($power['onlyif_six_dev'])) {
+                    } elseif (isset($power['onlyif_variable_vp'])) {
                         $html .= sprintf(self::_("Gain %s PRG if you place a 6 cost development"), $power['arg']['pr']) ;
                     } else {
                         $html .= sprintf(self::_("Gain %s PRG if you place a development"), $power['arg']['pr']) ;
@@ -1624,222 +1624,222 @@ class RaceForTheGalaxy extends Bga\GameFramework\Table
         return $html;
     }
 
-    function sixcostdev_html($card_type_id)
+    function variableVpScoringHtml($card_type_id)
     {
-        $html = "<table class='six_dev_scoring'>";
+        $html = "<table class='variable_vp_scoring'>";
 
         switch ($card_type_id) {
             case 11:
-                $html .= "<tr><td>{two_pts}</td><td>{brown_production}</td><td class='six_dev_scoring_text'>" . self::_("Rare elements production world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{brown_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Rare elements windfall world")."</td></tr>";
-                $html .= "<tr><td rowspan=2>{two_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Mining Robots")."</td></tr>";
-                $html .= "<tr><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Mining Conglomerate")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{brown_production}</td><td class='variable_vp_scoring_text'>" . self::_("Rare elements production world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{brown_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Rare elements windfall world")."</td></tr>";
+                $html .= "<tr><td rowspan=2>{two_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Mining Robots")."</td></tr>";
+                $html .= "<tr><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Mining Conglomerate")."</td></tr>";
                 break;
             case 21:
-                $html .= "<tr><td>{three_pts}</td><td>{yellow_production}</td><td class='six_dev_scoring_text'>" . self::_("Alien technology production world")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{yellow_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Alien technology windfall world")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>£ALIEN£</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{yellow_production}</td><td class='variable_vp_scoring_text'>" . self::_("Alien technology production world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{yellow_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Alien technology windfall world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>£ALIEN£</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
                 break;
             case 22:
-                $html .= "<tr><td>{two_pts}</td><td>{blue_production}</td><td class='six_dev_scoring_text'>" . self::_("Novelty production world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{blue_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Novelty windfall world")."</td></tr>";
-                $html .= "<tr><td rowspan=2>{two_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Consumer Markets")."</td></tr>";
-                $html .= "<tr><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Expanding Colony")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{blue_production}</td><td class='variable_vp_scoring_text'>" . self::_("Novelty production world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{blue_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Novelty windfall world")."</td></tr>";
+                $html .= "<tr><td rowspan=2>{two_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Consumer Markets")."</td></tr>";
+                $html .= "<tr><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Expanding Colony")."</td></tr>";
                 break;
             case 23:
-                $html .= "<tr><td>{two_pts}</td><td>{six_development}</td><td class='six_dev_scoring_text'>" . self::_("6-cost development (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{six_development}</td><td class='variable_vp_scoring_text'>" . self::_("6-cost development (including this one)")."</td></tr>";
                 if (self::getGameStateValue('expansion') == 4) {
-                    $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='six_dev_scoring_text'>" . self::_("other development")."</td></tr>";
+                    $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='variable_vp_scoring_text'>" . self::_("other development")."</td></tr>";
                 } else {
-                    $html .= "<tr><td>{one_pt}</td><td>{dev_lower_than_six}</td><td class='six_dev_scoring_text'>" . self::_("other development")."</td></tr>";
+                    $html .= "<tr><td>{one_pt}</td><td>{dev_lower_than_six}</td><td class='variable_vp_scoring_text'>" . self::_("other development")."</td></tr>";
                 }
                 break;
             case 24:
-                $html .=  "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='six_dev_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("other military world")."</td></tr>";
+                $html .=  "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='variable_vp_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other military world")."</td></tr>";
                 break;
             case 25:
-                $html .= "<tr><td>{one_pt}</td><td>{three_vp_chips}</td><td class='six_dev_scoring_text'>" . self::_("every three VPs in chips, rounded down")."</td></tr>";
-                $html .= "<tr><td rowspan=3>{three_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Research Labs")."</td></tr>";
-                $html .= "<tr><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Galactic Trendsetters")."</td></tr>";
-                $html .= "<tr><td>{blue_world}</td><td class='six_dev_scoring_name'>" . self::_("Artist Colony")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{three_vp_chips}</td><td class='variable_vp_scoring_text'>" . self::_("every three VPs in chips, rounded down")."</td></tr>";
+                $html .= "<tr><td rowspan=3>{three_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Research Labs")."</td></tr>";
+                $html .= "<tr><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Galactic Trendsetters")."</td></tr>";
+                $html .= "<tr><td>{blue_world}</td><td class='variable_vp_scoring_name'>" . self::_("Artist Colony")."</td></tr>";
                 break;
             case 26:
-                $html .= "<tr><td>{one_pt}</td><td>{dev_explore}</td><td class='six_dev_scoring_text'>" . self::_("development with an Explore power")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{world_explore}</td><td class='six_dev_scoring_text'>" . self::_("world with an Explore power")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{world}</td><td class='six_dev_scoring_text'>" . self::_("other world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{dev_explore}</td><td class='variable_vp_scoring_text'>" . self::_("development with an Explore power")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{world_explore}</td><td class='variable_vp_scoring_text'>" . self::_("world with an Explore power")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{world}</td><td class='variable_vp_scoring_text'>" . self::_("other world")."</td></tr>";
                 break;
             case 27:
-                $html .= "<tr><td>{two_pts}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='six_dev_scoring_text'>" . self::_("production world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{any_good}</td><td class='six_dev_scoring_text'>" . self::_("good at game end")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='variable_vp_scoring_text'>" . self::_("production world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{any_good}</td><td class='variable_vp_scoring_text'>" . self::_("good at game end")."</td></tr>";
                 break;
             case 28:
-                $html .= "<tr><td>{two_pts}</td><td>{dev_consume}</td><td class='six_dev_scoring_text'>" . self::_("development with a Consume power (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{world_consume}</td><td class='six_dev_scoring_text'>" . self::_("world with a Consume power")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{dev_consume}</td><td class='variable_vp_scoring_text'>" . self::_("development with a Consume power (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{world_consume}</td><td class='variable_vp_scoring_text'>" . self::_("world with a Consume power")."</td></tr>";
                 break;
 
             case 29:
-                $html .= "<tr><td>{X_pts}</td><td>{X_military}</td><td class='six_dev_scoring_text'>" . self::_("total Military (count negative Military but do not count specialized Military)")."</td></tr>";
+                $html .= "<tr><td>{X_pts}</td><td>{X_military}</td><td class='variable_vp_scoring_text'>" . self::_("total Military (count negative Military but do not count specialized Military)")."</td></tr>";
                 break;
 
             case 30:
-                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Genes world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("other military world")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td colspan=2>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Contact Specialist")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Genes world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other military world")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td colspan=2>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Contact Specialist")."</td></tr>";
                 break;
             case 31:
-                $html .= "<tr><td>{two_pts}</td><td>{dev_trade}</td><td class='six_dev_scoring_text'>" . self::_("development with a Trade power (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{world_trade}</td><td class='six_dev_scoring_text'>" . self::_("world with a Trade power")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{dev_trade}</td><td class='variable_vp_scoring_text'>" . self::_("development with a Trade power (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{world_trade}</td><td class='variable_vp_scoring_text'>" . self::_("world with a Trade power")."</td></tr>";
                 break;
 
         // The Gathering storm
             case 100:
-                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Genes world")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td colspan=2>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Genetics Lab")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Genes world")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td colspan=2>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Genetics Lab")."</td></tr>";
                 break;
             case 101:
-                $html .= "<tr><td>{two_pts}</td><td>{windfall_world}</td><td class='six_dev_scoring_text'>" . self::_("windfall world")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>€TERRA€</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{windfall_world}</td><td class='variable_vp_scoring_text'>" . self::_("windfall world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>€TERRA€</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
                 break;
             case 119:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("other military world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other military world")."</td></tr>";
                 break;
 
         // Rebel vs imperium
             case 146:
-                $html .= "<tr><td>{two_pts}</td><td>{brown_production}</td><td>{brown_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Rare elements world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2>{world}</td><td class='six_dev_scoring_text'>" . self::_("other world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2 class='six_dev_scoring_card_only'>€TERRA€</td><td colspan=3 class='six_dev_scoring_text'>" . self::_("€TERRAFORMING€ card")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{brown_production}</td><td>{brown_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Rare elements world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2>{world}</td><td class='variable_vp_scoring_text'>" . self::_("other world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2 class='variable_vp_scoring_card_only'>€TERRA€</td><td colspan=3 class='variable_vp_scoring_text'>" . self::_("€TERRAFORMING€ card")."</td></tr>";
                 break;
             case 147:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='six_dev_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='variable_vp_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
                 break;
             case 148:
-                $html .= "<tr class='six_dev_scoring_card_only'><td>{X_pts_no_slash}</td><td style='font-weight: bold'>1/3/6/10</td></tr>";
-                $html .= "<tr class='six_dev_scoring_card_only'><td colspan=2>{different_kinds}</td></tr>";
-                $html .= "<tr class='six_dev_scoring_tooltip_only'><td style='font-weight: bold'>1/3/6/10</td><td>{empty_pts}</td><td>" . self::_("1-4 different kinds of worlds")."{different_kinds}</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Diversified Economy")."</td></tr>";
+                $html .= "<tr class='variable_vp_scoring_card_only'><td>{X_pts_no_slash}</td><td style='font-weight: bold'>1/3/6/10</td></tr>";
+                $html .= "<tr class='variable_vp_scoring_card_only'><td colspan=2>{different_kinds}</td></tr>";
+                $html .= "<tr class='variable_vp_scoring_tooltip_only'><td style='font-weight: bold'>1/3/6/10</td><td>{empty_pts}</td><td>" . self::_("1-4 different kinds of worlds")."{different_kinds}</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Diversified Economy")."</td></tr>";
                 break;
             case 149:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>!REBEL!</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("!REBEL! card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("other military world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>!REBEL!</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("!REBEL! card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other military world")."</td></tr>";
                 break;
             case 150:
-                $html .= "<tr><td rowspan=3>{two_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Interstellar Bank")."</td></tr>";
-                $html .= "<tr><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Investment Credits")."</td></tr>";
-                $html .= "<tr><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Gambling World")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='six_dev_scoring_text'>" . self::_("other development (including this one)")."</td></tr>";
+                $html .= "<tr><td rowspan=3>{two_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Interstellar Bank")."</td></tr>";
+                $html .= "<tr><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Investment Credits")."</td></tr>";
+                $html .= "<tr><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Gambling World")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='variable_vp_scoring_text'>" . self::_("other development (including this one)")."</td></tr>";
                 break;
             case 152:
-                $html .= "<tr><td>{three_pts}</td><td class='six_dev_scoring_card_only'>{chromosome}</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("*UPLIFT* world with XX")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>*UPLIFT*</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("other *UPLIFT* card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td class='variable_vp_scoring_card_only'>{chromosome}</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("*UPLIFT* world with XX")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>*UPLIFT*</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("other *UPLIFT* card (including this one)")."</td></tr>";
                 break;
 
         // Brink of war
             case 192:
-                $html .= "<tr><td>{X_pts}</td><td>{X_minus_military}</td><td class='six_dev_scoring_text'>" . self::_("total negative Military (count negative Military as positive victory points)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("military world")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Pan-Galactic Mediator")."</td></tr>";
+                $html .= "<tr><td>{X_pts}</td><td>{X_minus_military}</td><td class='variable_vp_scoring_text'>" . self::_("total negative Military (count negative Military as positive victory points)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("military world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Pan-Galactic Mediator")."</td></tr>";
                 break;
             case 193:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>€TERRA€</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{six_development}</td><td class='six_dev_scoring_text'>" . self::_("other 6-cost development")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='six_dev_scoring_text'>" . self::_("production world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>€TERRA€</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{six_development}</td><td class='variable_vp_scoring_text'>" . self::_("other 6-cost development")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='variable_vp_scoring_text'>" . self::_("production world")."</td></tr>";
                 break;
             case 197:
-                $html .= "<tr><td>{two_pts}</td><td>{blue_production}</td><td>{blue_windfall}</td><td class='six_dev_scoring_text'>" . self::_("Novelty world")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td colspan=2>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Expanding Colony")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2>{world}</td><td class='six_dev_scoring_text'>" . self::_("other world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{blue_production}</td><td>{blue_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("Novelty world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td colspan=2>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Expanding Colony")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2>{world}</td><td class='variable_vp_scoring_text'>" . self::_("other world")."</td></tr>";
                 break;
             case 199:
-                $html .= "<tr><td>{one_pt}</td><td>PRG</td><td class='six_dev_scoring_text'>" . self::_("(additional)")."</td></tr>";
-                $html .= "<tr><td rowspan=3>{two_pts}</td><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Export Duties")."</td></tr>";
-                $html .= "<tr><td>{named_development}</td><td class='six_dev_scoring_name'>" . self::_("Galactic Renaissance")."</td></tr>";
-                $html .= "<tr><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>PRG</td><td class='variable_vp_scoring_text'>" . self::_("(additional)")."</td></tr>";
+                $html .= "<tr><td rowspan=3>{two_pts}</td><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Export Duties")."</td></tr>";
+                $html .= "<tr><td>{named_development}</td><td class='variable_vp_scoring_name'>" . self::_("Galactic Renaissance")."</td></tr>";
+                $html .= "<tr><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
                 break;
             case 201:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>£ALIEN£</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("£ALIEN£ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}</td><td class='six_dev_scoring_text'>" . self::_("other (non-£ALIEN£) production world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>£ALIEN£</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("£ALIEN£ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}</td><td class='variable_vp_scoring_text'>" . self::_("other (non-£ALIEN£) production world")."</td></tr>";
                 break;
 
         // Alien artifacts
 
             case 260:
-                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Alien Rosetta Stone World")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td class='six_dev_scoring_card_only'>£ALIEN£</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{alien_technology_token}</td><td class='six_dev_scoring_text'>" . self::_("Alien Technology token (additional)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Alien Rosetta Stone World")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td class='variable_vp_scoring_card_only'>£ALIEN£</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{alien_technology_token}</td><td class='variable_vp_scoring_text'>" . self::_("Alien Technology token (additional)")."</td></tr>";
                 break;
             case 261:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>€TERRA€</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{civil_world}</td><td class='six_dev_scoring_text'>" . self::_("other non-military world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{alien_science_token}</td><td class='six_dev_scoring_text'>" . self::_("Alien Science token (additional)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>€TERRA€</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{civil_world}</td><td class='variable_vp_scoring_text'>" . self::_("other non-military world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{alien_science_token}</td><td class='variable_vp_scoring_text'>" . self::_("Alien Science token (additional)")."</td></tr>";
                 break;
             case 262:
-                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='six_dev_scoring_card_only'>*UPLIFT*</td><td colspan=3 class='six_dev_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='six_dev_scoring_text'>" . self::_("other Genes world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2>{alien_uplift_token}</td><td class='six_dev_scoring_text'>" . self::_("Alien Uplift token (additional)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='variable_vp_scoring_card_only'>*UPLIFT*</td><td colspan=3 class='variable_vp_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{green_production}</td><td>{green_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("other Genes world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2>{alien_uplift_token}</td><td class='variable_vp_scoring_text'>" . self::_("Alien Uplift token (additional)")."</td></tr>";
                 break;
             case 263:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td>{brown_civil_windfall}</td><td class='six_dev_scoring_name'>" . self::_("Blaster Gem Mines")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='six_dev_scoring_text'>" . self::_("other military world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>+IMPERIUM+</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("+IMPERIUM+ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{brown_civil_windfall}</td><td class='variable_vp_scoring_name'>" . self::_("Blaster Gem Mines")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other military world")."</td></tr>";
                 break;
             case 264:
-                $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='six_dev_scoring_text'>" . self::_("development (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='six_dev_scoring_text'>" . self::_("production world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{development}</td><td class='variable_vp_scoring_text'>" . self::_("development (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='variable_vp_scoring_text'>" . self::_("production world")."</td></tr>";
                 break;
             case 265:
-                $html .= "<tr><td>{two_pts}</td><td colspan=2>{civil_world_trade}</td><td class='six_dev_scoring_text'>" . self::_("non-military world with a Trade power")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td colspan=2>{civil_world}</td><td class='six_dev_scoring_text'>" . self::_("other non-military world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{dev_trade}</td><td>{military_world_trade}</td><td class='six_dev_scoring_text'>" . self::_("other card with a Trade power (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td colspan=2>{civil_world_trade}</td><td class='variable_vp_scoring_text'>" . self::_("non-military world with a Trade power")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td colspan=2>{civil_world}</td><td class='variable_vp_scoring_text'>" . self::_("other non-military world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{dev_trade}</td><td>{military_world_trade}</td><td class='variable_vp_scoring_text'>" . self::_("other card with a Trade power (including this one)")."</td></tr>";
                 break;
 
         // Xeno invasion
             case 308:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>^AXENO^</td><td>{world}</td><td class='six_dev_scoring_text'>" . self::_("^ANTi-XENO^ world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{world}</td><td class='six_dev_scoring_text'>" . self::_("other world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td class='six_dev_scoring_card_only'>^AXENO^</td><td>{development}</td><td class='six_dev_scoring_text'>" . self::_("^ANTi-XENO^ development (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>^AXENO^</td><td>{world}</td><td class='variable_vp_scoring_text'>" . self::_("^ANTi-XENO^ world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{world}</td><td class='variable_vp_scoring_text'>" . self::_("other world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td class='variable_vp_scoring_card_only'>^AXENO^</td><td>{development}</td><td class='variable_vp_scoring_text'>" . self::_("^ANTi-XENO^ development (including this one)")."</td></tr>";
                 break;
             case 309:
-                $html .= "<tr><td>{one_pt}</td><td class='six_dev_scoring_card_only'>^AXENO^</td><td  colspan=2 class='six_dev_scoring_text'>" . self::_("^ANTi-XENO^ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='six_dev_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{xeno_military_world}</td><td class='six_dev_scoring_text'>" . self::_("other Xeno military world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td class='variable_vp_scoring_card_only'>^AXENO^</td><td  colspan=2 class='variable_vp_scoring_text'>" . self::_("^ANTi-XENO^ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{rebel_military_world}</td><td class='variable_vp_scoring_text'>" . self::_("Rebel military world")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{xeno_military_world}</td><td class='variable_vp_scoring_text'>" . self::_("other Xeno military world")."</td></tr>";
                 break;
             case 310:
-                $html .= "<tr><td>{three_pts}</td><td colspan=2>{brown_civil_windfall}</td><td class='six_dev_scoring_name'>" . self::_("Blaster Gem Mines")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td colspan=2>{brown_civil_production}</td><td class='six_dev_scoring_name'>" . self::_("Imperium Armaments World")."</td></tr>";
-                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='six_dev_scoring_card_only'>+IMPERIUM+</td><td colspan=3 class='six_dev_scoring_text'>" . self::_("other +IMPERIUM+ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{brown_production}</td><td>{brown_windfall}</td><td class='six_dev_scoring_text'>" . self::_("other Rare elements world")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td colspan=2>{brown_civil_windfall}</td><td class='variable_vp_scoring_name'>" . self::_("Blaster Gem Mines")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td colspan=2>{brown_civil_production}</td><td class='variable_vp_scoring_name'>" . self::_("Imperium Armaments World")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='variable_vp_scoring_card_only'>+IMPERIUM+</td><td colspan=3 class='variable_vp_scoring_text'>" . self::_("other +IMPERIUM+ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{brown_production}</td><td>{brown_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("other Rare elements world")."</td></tr>";
                 break;
             case 311:
-                $html .= "<tr><td>{two_pts}</td><td>{xeno_military_world}</td><td class='six_dev_scoring_text'>" . self::_("Xeno military world")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td>{yellow_civil_production}</td><td class='six_dev_scoring_name'>" . self::_("Alien Archives")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td class='six_dev_scoring_card_only'>£ALIEN£</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td>{xeno_military_world}</td><td class='variable_vp_scoring_text'>" . self::_("Xeno military world")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{yellow_civil_production}</td><td class='variable_vp_scoring_name'>" . self::_("Alien Archives")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td class='variable_vp_scoring_card_only'>£ALIEN£</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("other £ALIEN£ card (including this one)")."</td></tr>";
                 break;
             case 312:
-                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='six_dev_scoring_card_only'>*UPLIFT*</td><td colspan=3 class='six_dev_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{green_production}</td><td>{green_windfall}</td><td class='six_dev_scoring_text'>" . self::_("other Genes world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td colspan=2 class='variable_vp_scoring_card_only'>*UPLIFT*</td><td colspan=3 class='variable_vp_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{green_production}</td><td>{green_windfall}</td><td class='variable_vp_scoring_text'>" . self::_("other Genes world")."</td></tr>";
                 break;
             case 313:
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>€TERRA€</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
-                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='six_dev_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
-                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='six_dev_scoring_text'>" . self::_("production world")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>€TERRA€</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("€TERRAFORMING€ card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{three_pts}</td><td>{grey_world}</td><td class='variable_vp_scoring_name'>" . self::_("Terraformed World")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td>{blue_production}{brown_production}<br>{green_production}{yellow_production}</td><td class='variable_vp_scoring_text'>" . self::_("production world")."</td></tr>";
                 break;
 
             // Worlds with 6cost dev-like scoring
 
             case 247: // Alien Uplift Chamber
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>*UPLIFT*</td><td class='six_dev_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>*UPLIFT*</td><td class='variable_vp_scoring_text'>" . self::_("*UPLIFT* card (including this one)")."</td></tr>";
                 break;
             case 267: // Rebel Resistance from Alien Artefact
-                $html .= "<tr><td>{two_pts}</td><td class='six_dev_scoring_card_only'>!REBEL!</td><td colspan=2 class='six_dev_scoring_text'>" . self::_("!REBEL! card (including this one)")."</td></tr>";
+                $html .= "<tr><td>{two_pts}</td><td class='variable_vp_scoring_card_only'>!REBEL!</td><td colspan=2 class='variable_vp_scoring_text'>" . self::_("!REBEL! card (including this one)")."</td></tr>";
                 break;
             case 283: // Corrosive Uplift World
             case 294: // Uplift Coalition
-                $html .= "<tr><td>{one_pt}</td><td class='six_dev_scoring_card_only'>{chromosome}</td><td class='six_dev_scoring_text'>" . self::_("*UPLIFT* world with XX (including this one)")."</td></tr>";
+                $html .= "<tr><td>{one_pt}</td><td class='variable_vp_scoring_card_only'>{chromosome}</td><td class='variable_vp_scoring_text'>" . self::_("*UPLIFT* world with XX (including this one)")."</td></tr>";
                 break;
             }
 
@@ -2220,7 +2220,7 @@ class RaceForTheGalaxy extends Bga\GameFramework\Table
                 continue;
             }
 
-            if (isset($power['onlyif_six_dev']) && $card_type['cost'] != 6) {
+            if (isset($power['onlyif_variable_vp']) && $card_type['cost'] != 6) {
                 continue;
             }
 

--- a/raceforthegalaxy.js
+++ b/raceforthegalaxy.js
@@ -1056,7 +1056,7 @@ define([
                 var card_type = this.gamedatas.card_types[card_type_id];
                 var card_name = card_type.nametr; // Card name (translated)
                 var tooltip = this.replaceImages(card_type.tooltip);
-                var sixdev_scoring = card_type.sixdev_scoring;
+                var variable_vp_scoring = card_type.variable_vp_scoring;
 
                 // Add card content
                 var card_id = '';
@@ -1069,11 +1069,11 @@ define([
                 if (card_type_id == 181) {
                     dojo.place(`<div id="scavengericon_${card_id}" class="scavengericon"/>`, id);
                 }
-                if (sixdev_scoring != undefined) {
-                    sixdev_scoring = this.replaceImages(sixdev_scoring);
-                    sixdev_scoring = this.colorToName(sixdev_scoring);
-                    tooltip += '<hr/>' + sixdev_scoring;
-                    dojo.place(`<div id="six_dev_${card_id}" class="six_dev">${sixdev_scoring}</div>`, id);
+                if (variable_vp_scoring != undefined) {
+                    variable_vp_scoring = this.replaceImages(variable_vp_scoring);
+                    variable_vp_scoring = this.colorToName(variable_vp_scoring);
+                    tooltip += '<hr/>' + variable_vp_scoring;
+                    dojo.place(`<div id="variable_vp_${card_id}" class="variable_vp">${variable_vp_scoring}</div>`, id);
                 }
 
                 dojo.style(id, "background-size", "auto " + this.card_size['h'] * 10 + "px");


### PR DESCRIPTION
<git-pr-chain>


Rename "six-cost dev" to "variable-point card"

The expansions have variable-point costs that are not six-cost
developments, and also there is a six-cost development that is not
variable-point.  It felt weird to continue using this outdated
terminology in a future PR where I'm adding live scoring of
variable-point cards.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #10 👈 **YOU ARE HERE**
1. #11
1. #5


</git-pr-chain>
